### PR TITLE
✨[FEAT] iOS 4차 과제(#10)

### DIFF
--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment.xcodeproj/project.pbxproj
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment.xcodeproj/project.pbxproj
@@ -603,7 +603,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "hyun99999.SOPT-29th-iOS-SeminarAssignment";
+				PRODUCT_BUNDLE_IDENTIFIER = hyun99999.YoutubCloneCoding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -633,7 +633,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "hyun99999.SOPT-29th-iOS-SeminarAssignment";
+				PRODUCT_BUNDLE_IDENTIFIER = hyun99999.YoutubCloneCoding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment.xcodeproj/project.pbxproj
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment.xcodeproj/project.pbxproj
@@ -31,6 +31,15 @@
 		F8D2BE75270848FF00ED5EEA /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8D2BE73270848FF00ED5EEA /* Login.storyboard */; };
 		F8D2BE77270848FF00ED5EEA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8D2BE76270848FF00ED5EEA /* Assets.xcassets */; };
 		F8D2BE7A270848FF00ED5EEA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8D2BE78270848FF00ED5EEA /* LaunchScreen.storyboard */; };
+		F8D648152736F01500B4EF34 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D648142736F01500B4EF34 /* NetworkResult.swift */; };
+		F8D648172736F01D00B4EF34 /* GenericResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D648162736F01D00B4EF34 /* GenericResponse.swift */; };
+		F8D6481B2736F06800B4EF34 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D6481A2736F06800B4EF34 /* URL.swift */; };
+		F8D6481D2736F1F000B4EF34 /* SignupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D6481C2736F1F000B4EF34 /* SignupService.swift */; };
+		F8D6481F2736F2AF00B4EF34 /* SignupResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D6481E2736F2AF00B4EF34 /* SignupResponseModel.swift */; };
+		F8D648242736F86900B4EF34 /* UIViewController+alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D648232736F86900B4EF34 /* UIViewController+alert.swift */; };
+		F8D648262736F9B400B4EF34 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D648252736F9B400B4EF34 /* LoginService.swift */; };
+		F8D648282736FA6400B4EF34 /* LoginResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D648272736FA6400B4EF34 /* LoginResponseModel.swift */; };
+		F8D6482A27379D8C00B4EF34 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D6482927379D8C00B4EF34 /* UserDefaults.swift */; };
 		F8E70BEF270F4D0100A7DAF2 /* Signup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8E70BEE270F4D0100A7DAF2 /* Signup.storyboard */; };
 		F8E70BF1270F4D0C00A7DAF2 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E70BF0270F4D0C00A7DAF2 /* SignupViewController.swift */; };
 		F8E70BF3270F4D6B00A7DAF2 /* CheckinViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E70BF2270F4D6B00A7DAF2 /* CheckinViewController.swift */; };
@@ -70,6 +79,15 @@
 		F8D2BE76270848FF00ED5EEA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F8D2BE79270848FF00ED5EEA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F8D2BE7B270848FF00ED5EEA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F8D648142736F01500B4EF34 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
+		F8D648162736F01D00B4EF34 /* GenericResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericResponse.swift; sourceTree = "<group>"; };
+		F8D6481A2736F06800B4EF34 /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
+		F8D6481C2736F1F000B4EF34 /* SignupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupService.swift; sourceTree = "<group>"; };
+		F8D6481E2736F2AF00B4EF34 /* SignupResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupResponseModel.swift; sourceTree = "<group>"; };
+		F8D648232736F86900B4EF34 /* UIViewController+alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+alert.swift"; sourceTree = "<group>"; };
+		F8D648252736F9B400B4EF34 /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
+		F8D648272736FA6400B4EF34 /* LoginResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseModel.swift; sourceTree = "<group>"; };
+		F8D6482927379D8C00B4EF34 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		F8E70BEE270F4D0100A7DAF2 /* Signup.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Signup.storyboard; sourceTree = "<group>"; };
 		F8E70BF0270F4D0C00A7DAF2 /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
 		F8E70BF2270F4D6B00A7DAF2 /* CheckinViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckinViewController.swift; sourceTree = "<group>"; };
@@ -106,7 +124,6 @@
 				B08B034AABFE2509BE3D294D /* Pods-SOPT-29th-iOS-SeminarAssignment.debug.xcconfig */,
 				682D272BCCB16C086AFE7213 /* Pods-SOPT-29th-iOS-SeminarAssignment.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -176,9 +193,38 @@
 			isa = PBXGroup;
 			children = (
 				F8E70BEA270F4BF900A7DAF2 /* Resource */,
+				F8D648222736F7E200B4EF34 /* Extensions */,
 				F8E70BEB270F4C0300A7DAF2 /* Source */,
 			);
 			path = "SOPT-29th-iOS-SeminarAssignment";
+			sourceTree = "<group>";
+		};
+		F8D648182736F02000B4EF34 /* NetworkModel */ = {
+			isa = PBXGroup;
+			children = (
+				F8D648162736F01D00B4EF34 /* GenericResponse.swift */,
+				F8D648142736F01500B4EF34 /* NetworkResult.swift */,
+				F8D6481E2736F2AF00B4EF34 /* SignupResponseModel.swift */,
+				F8D648272736FA6400B4EF34 /* LoginResponseModel.swift */,
+			);
+			path = NetworkModel;
+			sourceTree = "<group>";
+		};
+		F8D648192736F02D00B4EF34 /* NetworkService */ = {
+			isa = PBXGroup;
+			children = (
+				F8D6481C2736F1F000B4EF34 /* SignupService.swift */,
+				F8D648252736F9B400B4EF34 /* LoginService.swift */,
+			);
+			path = NetworkService;
+			sourceTree = "<group>";
+		};
+		F8D648222736F7E200B4EF34 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				F8D648232736F86900B4EF34 /* UIViewController+alert.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		F8E70BEA270F4BF900A7DAF2 /* Resource */ = {
@@ -197,6 +243,8 @@
 			children = (
 				F8E70BFD270F503A00A7DAF2 /* AppDelegate.swift */,
 				F8D2BE6F270848FF00ED5EEA /* SceneDelegate.swift */,
+				F8D648182736F02000B4EF34 /* NetworkModel */,
+				F8D648192736F02D00B4EF34 /* NetworkService */,
 				F8786C83272B345700BAD7CE /* Model */,
 				F8786C74272B29C800BAD7CE /* Cell */,
 				F8786C6B272AE5B900BAD7CE /* View */,
@@ -235,6 +283,8 @@
 				F8E70BF9270F4E8B00A7DAF2 /* Storyboard.swift */,
 				F8E70BFB270F4EB000A7DAF2 /* ViewController.swift */,
 				F8786C7D272B2B3A00BAD7CE /* Xib.swift */,
+				F8D6481A2736F06800B4EF34 /* URL.swift */,
+				F8D6482927379D8C00B4EF34 /* UserDefaults.swift */,
 			);
 			path = Const;
 			sourceTree = "<group>";
@@ -364,24 +414,33 @@
 				F8E70BFE270F503A00A7DAF2 /* AppDelegate.swift in Sources */,
 				F86E5201271DE11F00D57993 /* LibraryViewController.swift in Sources */,
 				F86E5203271DE14900D57993 /* PlusViewController.swift in Sources */,
+				F8D648242736F86900B4EF34 /* UIViewController+alert.swift in Sources */,
 				F8786C85272B349B00BAD7CE /* ChannelData.swift in Sources */,
 				F8786C81272B2BA600BAD7CE /* ThumbnailTableViewCell.swift in Sources */,
+				F8D648172736F01D00B4EF34 /* GenericResponse.swift in Sources */,
+				F8D6481F2736F2AF00B4EF34 /* SignupResponseModel.swift in Sources */,
 				F8786C7B272B29E300BAD7CE /* CategoryCollectionViewCell.swift in Sources */,
 				F8D2BE72270848FF00ED5EEA /* LoginViewController.swift in Sources */,
+				F8D6481D2736F1F000B4EF34 /* SignupService.swift in Sources */,
 				F8E70BF1270F4D0C00A7DAF2 /* SignupViewController.swift in Sources */,
 				F8E70BF3270F4D6B00A7DAF2 /* CheckinViewController.swift in Sources */,
 				F86E51FD271DE06F00D57993 /* TabBarViewController.swift in Sources */,
 				F86E51FF271DE11400D57993 /* HomeViewController.swift in Sources */,
 				F8786C7E272B2B3A00BAD7CE /* Xib.swift in Sources */,
 				F8D2BE70270848FF00ED5EEA /* SceneDelegate.swift in Sources */,
+				F8D648152736F01500B4EF34 /* NetworkResult.swift in Sources */,
 				F8786C6D272AE69700BAD7CE /* CustomNavigationBar.swift in Sources */,
 				F8786C77272B29D700BAD7CE /* ChannelCollectionViewCell.swift in Sources */,
 				F8E70BFC270F4EB000A7DAF2 /* ViewController.swift in Sources */,
+				F8D648282736FA6400B4EF34 /* LoginResponseModel.swift in Sources */,
 				F86E5205271DE16100D57993 /* SubscriptionViewController.swift in Sources */,
 				F8E70BFA270F4E8B00A7DAF2 /* Storyboard.swift in Sources */,
 				F8E70BF8270F4E7E00A7DAF2 /* Const.swift in Sources */,
 				F86E5207271DE16E00D57993 /* ShortsViewController.swift in Sources */,
+				F8D6482A27379D8C00B4EF34 /* UserDefaults.swift in Sources */,
 				F8786C87272B34AA00BAD7CE /* ThumbnailData.swift in Sources */,
+				F8D6481B2736F06800B4EF34 /* URL.swift in Sources */,
+				F8D648262736F9B400B4EF34 /* LoginService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Extensions/UIViewController+alert.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Extensions/UIViewController+alert.swift
@@ -15,8 +15,9 @@ extension UIViewController {
                    okAction : ((UIAlertAction) -> Void)? = nil,
                    completion : (() -> ())? = nil)
     {
-        
+        // creates haptics to simulate physical impacts.
         let generator = UIImpactFeedbackGenerator(style: .medium)
+        // triggers impoact feedback.
         generator.impactOccurred()
         
         let alertViewController = UIAlertController(title: title, message: message,

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Extensions/UIViewController+alert.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Extensions/UIViewController+alert.swift
@@ -1,0 +1,30 @@
+//
+//  UIViewController+alert.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import UIKit
+
+
+extension UIViewController {
+    // ❗️4차 - UIAlertController 를 쉽게 만들 수 있도록 커스텀한 메서드.
+    func makeAlert(title : String,
+                   message : String,
+                   okAction : ((UIAlertAction) -> Void)? = nil,
+                   completion : (() -> ())? = nil)
+    {
+        
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        
+        let alertViewController = UIAlertController(title: title, message: message,
+                                                    preferredStyle: .alert)
+        
+        let okAction = UIAlertAction(title: "확인", style: .default, handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Resource/Const/URL.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Resource/Const/URL.swift
@@ -1,0 +1,19 @@
+//
+//  URL.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import Foundation
+
+extension Const {
+    struct URL {
+        // MARK: - Base URL
+        static let baseURL = "https://asia-northeast3-we-sopt-29.cloudfunctions.net/api"
+        
+        // MARK: - Feature URL
+        static let signupURL = baseURL + "/user/signup"
+        static let loginURL = baseURL + "/user/login"
+    }
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Resource/Const/UserDefaults.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Resource/Const/UserDefaults.swift
@@ -1,0 +1,15 @@
+//
+//  UserDefaults.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import Foundation
+extension Const {
+    struct UserDefaults {
+        struct Key {
+            static let userName = "UserName"
+        }
+    }
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Resource/Storyboard/TabBar.storyboard
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Resource/Storyboard/TabBar.storyboard
@@ -106,7 +106,7 @@
                     <connections>
                         <outlet property="categoryCollectionView" destination="5oQ-t9-WdF" id="gSh-pN-xh9"/>
                         <outlet property="channelCollectionView" destination="ceV-jc-46d" id="Ks8-5a-RyQ"/>
-                        <outlet property="customNavigationBar" destination="cm9-Ap-Uzb" id="vDI-1t-vf2"/>
+                        <outlet property="customNavigationBar" destination="cm9-Ap-Uzb" id="aRO-Qv-Ji2"/>
                         <outlet property="thumbnailTableView" destination="fos-su-oGk" id="Wg3-qN-O8g"/>
                     </connections>
                 </viewController>

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/GenericResponse.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/GenericResponse.swift
@@ -1,0 +1,32 @@
+//
+//  GenericResponse.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import Foundation
+
+struct GenericResponse<T: Codable>: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: T?
+    
+    enum CodingKeys: String, CodingKey {
+        case status
+        case success
+        case message
+        case data
+    }
+    
+    // ❗️4차 - 직접 decode 를 해서 서버에서 비어있는 key-value 가 넘어오게되면 기본값을 넣어주는 예외처리.
+    // 이렇게 하면 서버에서 key-value 를 넘겨주지 않더라도 앱이 갑자기 죽지 않아요! 또는 모든 타입을 옵셔널로 처리해주는 방법도 있어요.
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        status = (try? values.decode(Int.self, forKey: .status)) ?? 0
+        success = (try? values.decode(Bool.self, forKey: .success)) ?? false
+        message = (try? values.decode(String.self, forKey: .message)) ?? ""
+        data = (try? values.decode(T.self, forKey: .data)) ?? nil
+    }
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/LoginResponseModel.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/LoginResponseModel.swift
@@ -1,0 +1,14 @@
+//
+//  LoginResponseModel.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import Foundation
+
+// post 요청시 response body 가 될 model
+struct LoginResponseModel: Codable {
+    let id: Int
+    let name, email: String
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/NetworkResult.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/NetworkResult.swift
@@ -1,0 +1,15 @@
+//
+//  NetworkResult.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+import Foundation
+
+enum NetworkResult<T> {
+    case success(T)         // 서버통신 성공
+    case requestErr(T)      // 요청 에러
+    case pathErr            // 경로 에러
+    case serverErr          // 서버 내부 에러
+    case networkFail        // 네트워크 연결 실패
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/NetworkResult.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/NetworkResult.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 enum NetworkResult<T> {
-    case success(T)         // 서버통신 성공
+    case success(T, T)         // 서버통신 성공
     case requestErr(T)      // 요청 에러
     case pathErr            // 경로 에러
     case serverErr          // 서버 내부 에러

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/SignupResponseModel.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkModel/SignupResponseModel.swift
@@ -1,0 +1,16 @@
+//
+//  SignupResponseModel.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import Foundation
+
+// post 요청시 response body 가 될 model
+struct SignupResponseModel: Codable {
+    let id: Int
+    let name: String
+//    let password: String
+    let email: String
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/LoginService.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/LoginService.swift
@@ -1,0 +1,64 @@
+//
+//  LoginService.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import Foundation
+import Alamofire
+
+struct LoginService {
+    static let shared = LoginService()
+    
+    func login(email: String,
+               password: String,
+               completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        
+        let url = Const.URL.loginURL
+        
+        let header: HTTPHeaders = [
+            "Content-Type" : "application/json"
+        ]
+        
+        let body: Parameters = [
+            "email" : email,
+            "password" : password
+        ]
+        
+        let dataRequest = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: header)
+        
+        dataRequest.responseData { dataResponse in
+            switch dataResponse.result {
+            case .success:
+                guard let statusCode = dataResponse.response?.statusCode else { return }
+                guard let data = dataResponse.data else { return }
+                let networkResult = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+                completion(.networkFail)
+            }
+        }
+    }
+    
+    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        switch statusCode {
+        case 200: return isValidLoginData(data: data, valid: true)
+        // ❗️4차 - 대표적으로 잘못된 경로를 요청하는 404 의 경우도 분기처리하기 위해서 400~499 로 설정
+        case 400..<500: return isValidLoginData(data: data, valid: false)
+        case 500: return .serverErr
+        default : return .networkFail
+        }
+    }
+    
+    private func isValidLoginData(data: Data, valid: Bool) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<LoginResponseModel>.self, from: data) else { return .pathErr}
+        if valid {
+            return .success(decodedData.data)
+        } else {
+            return .requestErr(decodedData.message)
+        }
+    }
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/LoginService.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/LoginService.swift
@@ -56,7 +56,7 @@ struct LoginService {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<LoginResponseModel>.self, from: data) else { return .pathErr}
         if valid {
-            return .success(decodedData.data)
+            return .success(decodedData.data, decodedData.message)
         } else {
             return .requestErr(decodedData.message)
         }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/SignupService.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/SignupService.swift
@@ -1,0 +1,68 @@
+//
+//  SignupService.swift
+//  SOPT-29th-iOS-SeminarAssignment
+//
+//  Created by kimhyungyu on 2021/11/07.
+//
+
+import Foundation
+import Alamofire
+
+struct SignupService {
+    static let shared = SignupService()
+    
+    func signup(email: String,
+                name: String,
+                password: String,
+                completion: @escaping ((NetworkResult<Any>) -> Void)) {
+    
+        let url = Const.URL.signupURL
+        
+        let header: HTTPHeaders = [
+            "Content-Type" : "application/json"
+        ]
+        
+        let body: Parameters = [
+            "email" : email,
+            "name" : name,
+            "password" : password
+        ]
+        
+        let dataRequest = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: header)
+        
+        dataRequest.responseData { dataResponse in
+            switch dataResponse.result {
+            case .success:
+                guard let statusCode = dataResponse.response?.statusCode else { return }
+                guard let data = dataResponse.data else { return }
+                
+                let networkResult = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err)
+                completion(.networkFail)
+            }
+        }
+    }
+    
+    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        switch statusCode {
+        case 200: return isValidSignupData(data: data, valid: true)
+        // ❗️4차 - 대표적으로 잘못된 경로를 요청하는 404 의 경우도 분기처리하기 위해서 400~499 로 설정
+        case 400..<500: return isValidSignupData(data: data, valid: false)
+        case 500: return .serverErr
+        default : return .networkFail
+        }
+    }
+    
+    private func isValidSignupData(data: Data, valid: Bool) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<SignupResponseModel>.self, from: data) else { return .pathErr }
+        if valid {
+            return .success(decodedData.data)
+        } else {
+            return .requestErr(decodedData.message)
+        }
+    }
+}

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/SignupService.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/NetworkService/SignupService.swift
@@ -60,7 +60,7 @@ struct SignupService {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<SignupResponseModel>.self, from: data) else { return .pathErr }
         if valid {
-            return .success(decodedData.data)
+            return .success(decodedData.data, decodedData.message)
         } else {
             return .requestErr(decodedData.message)
         }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/View/CustomNavigationBar.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/View/CustomNavigationBar.swift
@@ -9,6 +9,17 @@ import Foundation
 import UIKit
 
 class CustomNavigationBar: UIView {
+    
+    // MARK: - Properties
+    
+    var presentingViewController: UIViewController?
+    
+    // MARK: - IBoutlet Properties
+    
+    @IBOutlet weak var profileButton: UIButton!
+    
+    // MARK: - Initializer
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
 //        customInit()
@@ -18,6 +29,7 @@ class CustomNavigationBar: UIView {
         super.init(coder: coder)
 //        customInit()
     }
+    
     // ✅ File's Owner 의 Custom Class 를 설정했을 때 사용하는 코드
 //    func customInit() {
 //        if let view = Bundle.main.loadNibNamed(Const.Xib.NibName.customNavigationBar, owner: self, options: nil)?.first as? UIView {
@@ -25,4 +37,16 @@ class CustomNavigationBar: UIView {
 //            addSubview(view)
 //        }
 //    }
+
+    // ✅ profile button 을 터치하면 LoginViewController 로 화면전환.
+    @IBAction func touchProfileButton(_ sender: Any) {
+        // ❗️4차 - LoginViewController 에서 화면전환은 push 와 pop 을 사용하기 때문에 LoginViewController 를 rootViewController 로 가지는 UINavigationController 를 코드로 구현.
+        guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginViewController else { return }
+        let navigationController = UINavigationController(rootViewController: loginVC)
+        
+        navigationController.modalPresentationStyle = .fullScreen
+        navigationController.modalTransitionStyle = .crossDissolve
+        presentingViewController?.present(navigationController, animated: true, completion: nil)
+    }
+    
 }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/View/CustomNavigationBar.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/View/CustomNavigationBar.swift
@@ -48,5 +48,4 @@ class CustomNavigationBar: UIView {
         navigationController.modalTransitionStyle = .crossDissolve
         presentingViewController?.present(navigationController, animated: true, completion: nil)
     }
-    
 }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/View/CustomNavigationBar.xib
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/View/CustomNavigationBar.xib
@@ -3,7 +3,6 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,38 +17,45 @@
                     <rect key="frame" x="16" y="10" width="96" height="105"/>
                 </imageView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="SearchIcon" translatesAutoresizingMaskIntoConstraints="NO" id="a8s-dY-YvN">
-                    <rect key="frame" x="326" y="10" width="32" height="105"/>
-                </imageView>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wesoptProfile" translatesAutoresizingMaskIntoConstraints="NO" id="Yo1-b2-Enl">
-                    <rect key="frame" x="368" y="10" width="36" height="105"/>
+                    <rect key="frame" x="312" y="10" width="32" height="105"/>
                 </imageView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="notificationIcon" translatesAutoresizingMaskIntoConstraints="NO" id="QTM-RF-oKf">
-                    <rect key="frame" x="284" y="10" width="32" height="105"/>
+                    <rect key="frame" x="270" y="10" width="32" height="105"/>
                 </imageView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="windowSharingIcon" translatesAutoresizingMaskIntoConstraints="NO" id="IlX-tg-jT6">
-                    <rect key="frame" x="242" y="10" width="32" height="105"/>
+                    <rect key="frame" x="228" y="10" width="32" height="105"/>
                 </imageView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lCl-iZ-Hxb">
+                    <rect key="frame" x="354" y="0.0" width="60" height="125"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="wesoptProfile"/>
+                    <connections>
+                        <action selector="touchProfileButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="pp7-9k-NgB"/>
+                    </connections>
+                </button>
             </subviews>
-            <viewLayoutGuide key="safeArea" id="fkN-bo-rk1"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="H8N-De-fJe" secondAttribute="bottom" constant="10" id="9VW-ZX-mxg"/>
                 <constraint firstAttribute="bottom" secondItem="a8s-dY-YvN" secondAttribute="bottom" constant="10" id="Eiv-LO-p0q"/>
-                <constraint firstItem="Yo1-b2-Enl" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="Hnb-gp-qKl"/>
+                <constraint firstItem="lCl-iZ-Hxb" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="LR1-sz-ITJ"/>
                 <constraint firstItem="H8N-De-fJe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="MG1-9I-VCH"/>
                 <constraint firstItem="IlX-tg-jT6" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="MOV-lB-20W"/>
-                <constraint firstItem="Yo1-b2-Enl" firstAttribute="leading" secondItem="a8s-dY-YvN" secondAttribute="trailing" constant="10" id="OKg-aL-925"/>
                 <constraint firstItem="QTM-RF-oKf" firstAttribute="leading" secondItem="IlX-tg-jT6" secondAttribute="trailing" constant="10" id="OQf-4q-X5G"/>
-                <constraint firstAttribute="trailing" secondItem="Yo1-b2-Enl" secondAttribute="trailing" constant="10" id="PuV-z2-sAz"/>
                 <constraint firstItem="a8s-dY-YvN" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="T9O-s9-z2i"/>
+                <constraint firstItem="lCl-iZ-Hxb" firstAttribute="leading" secondItem="a8s-dY-YvN" secondAttribute="trailing" constant="10" id="Ur4-N3-hdJ"/>
+                <constraint firstAttribute="trailing" secondItem="lCl-iZ-Hxb" secondAttribute="trailing" id="YuA-CG-p3G"/>
                 <constraint firstAttribute="bottom" secondItem="IlX-tg-jT6" secondAttribute="bottom" constant="10" id="Zx2-w5-cgc"/>
                 <constraint firstItem="QTM-RF-oKf" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="bsa-dd-fip"/>
                 <constraint firstItem="H8N-De-fJe" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="fsR-SX-PaJ"/>
-                <constraint firstAttribute="bottom" secondItem="Yo1-b2-Enl" secondAttribute="bottom" constant="10" id="l7m-2a-38U"/>
                 <constraint firstItem="a8s-dY-YvN" firstAttribute="leading" secondItem="QTM-RF-oKf" secondAttribute="trailing" constant="10" id="tgD-bU-FYd"/>
                 <constraint firstAttribute="bottom" secondItem="QTM-RF-oKf" secondAttribute="bottom" constant="10" id="ugK-Wv-JRA"/>
+                <constraint firstAttribute="bottom" secondItem="lCl-iZ-Hxb" secondAttribute="bottom" id="y2h-20-VDY"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="profileButton" destination="lCl-iZ-Hxb" id="TwT-bA-eB4"/>
+            </connections>
             <point key="canvasLocation" x="131.8840579710145" y="-392.07589285714283"/>
         </view>
     </objects>

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/CheckinViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/CheckinViewController.swift
@@ -35,13 +35,13 @@ class CheckinViewController: UIViewController {
     }
     
     @IBAction func touchLoginButton(_ sender: Any) {
-        // popToRootViewController 메서드 사용
+        // ✅ popToRootViewController 메서드 사용
 //        guard let presentingVC = self.presentingViewController as? UINavigationController else { return }
 //        self.dismiss(animated: true) {
 //            presentingVC.popToRootViewController(animated: true)
 //        }
         
-        // popToViewController 메서드 사용
+        // ✅ popToViewController 메서드 사용
         guard let presentingVC = self.presentingViewController as? UINavigationController else { return }
         let viewControllerStack = presentingVC.viewControllers
         self.dismiss(animated: true) {
@@ -58,7 +58,7 @@ class CheckinViewController: UIViewController {
 
 extension CheckinViewController {
     private func setUI() {
-        userNameLabel.text = userName
+        userNameLabel.text =  UserDefaults.standard.string(forKey: Const.UserDefaults.Key.userName)
     }
 }
 

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/CheckinViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/CheckinViewController.swift
@@ -9,10 +9,6 @@ import UIKit
 
 class CheckinViewController: UIViewController {
     
-    // MARK: - Properties
-    
-    var userName: String?
-    
     // MARK: - @IBOutlet Properties
     
     @IBOutlet weak var userNameLabel: UILabel!

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/LoginViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/LoginViewController.swift
@@ -45,14 +45,7 @@ class LoginViewController: UIViewController {
         navigationController?.pushViewController(signupVC, animated: true)
     }
     @IBAction func touchCheckinButton(_ sender: Any) {
-        let storyboard = UIStoryboard(name: Const.Storyboard.Name.checkin, bundle: nil)
-        guard let checkinVC = storyboard.instantiateViewController(withIdentifier: Const.ViewController.Identifier.checkin) as? CheckinViewController else {
-            return
-        }
-        
-        checkinVC.userName = nameTextField.text
-        checkinVC.modalPresentationStyle = .fullScreen
-        present(checkinVC, animated: true, completion: nil)
+        postLoginWithAPI()
     }
 }
 
@@ -72,6 +65,48 @@ extension LoginViewController {
     private func initTextFieldEmpty() {
         textFieldList.forEach {
             $0.text = ""
+        }
+    }
+    private func presentToCheckinViewController() {
+        let storyboard = UIStoryboard(name: Const.Storyboard.Name.checkin, bundle: nil)
+        guard let checkinVC = storyboard.instantiateViewController(withIdentifier: Const.ViewController.Identifier.checkin) as? CheckinViewController else {
+            return
+        }
+        
+        checkinVC.userName = nameTextField.text
+        checkinVC.modalPresentationStyle = .fullScreen
+        present(checkinVC, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Network
+
+extension LoginViewController {
+    func postLoginWithAPI() {
+        LoginService.shared.login(email: contactTextField.text ?? "",
+                                  password: passwordTextField.text ?? "") { response in
+            switch response {
+            case .success(let loginResponse):
+                if let data = loginResponse as? LoginResponseModel {
+                    // ✅ UserDefaults 로 이름을 저장
+                    UserDefaults.standard.set(data.name, forKey: Const.UserDefaults.Key.userName)
+                    // ✅ UIAlertController 를 만드는 커스텀 메서드
+                    self.makeAlert(title: "로그인", message: "로그인 성공", okAction: { _ in
+                        self.presentToCheckinViewController()
+                    })
+                }
+            case .requestErr(let message):
+                if let message = message as? String {
+                    self.makeAlert(title: "로그인", message: message)
+                }
+            case .pathErr:
+                print("postLoginWithAPI - pathErr")
+            case .serverErr:
+                print("postLoginWithAPI - serverErr")
+            case .networkFail:
+                print("postLoginWithAPI - networkFail")
+            }
+            
         }
     }
 }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/LoginViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/LoginViewController.swift
@@ -73,7 +73,6 @@ extension LoginViewController {
             return
         }
         
-        checkinVC.userName = nameTextField.text
         checkinVC.modalPresentationStyle = .fullScreen
         present(checkinVC, animated: true, completion: nil)
     }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/LoginViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/LoginViewController.swift
@@ -85,12 +85,12 @@ extension LoginViewController {
         LoginService.shared.login(email: contactTextField.text ?? "",
                                   password: passwordTextField.text ?? "") { response in
             switch response {
-            case .success(let loginResponse):
-                if let data = loginResponse as? LoginResponseModel {
+            case .success(let loginResponse, let message):
+                if let data = loginResponse as? LoginResponseModel, let message = message as? String {
                     // ✅ UserDefaults 로 이름을 저장
                     UserDefaults.standard.set(data.name, forKey: Const.UserDefaults.Key.userName)
                     // ✅ UIAlertController 를 만드는 커스텀 메서드
-                    self.makeAlert(title: "로그인", message: "로그인 성공", okAction: { _ in
+                    self.makeAlert(title: "로그인", message: message, okAction: { _ in
                         self.presentToCheckinViewController()
                     })
                 }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/SignupViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/SignupViewController.swift
@@ -86,10 +86,10 @@ extension SignupViewController {
     func postSignupWithAPI() {
         SignupService.shared.signup(email: contactTextField.text ?? "", name: nameTextField.text ?? "", password: passwordTextField.text ?? "") { response in
             switch response {
-            case .success(let signupResponse):
-                if let data = signupResponse as? SignupResponseModel {
+            case .success(let signupResponse, let message):
+                if let data = signupResponse as? SignupResponseModel, let message = message as? String {
                     UserDefaults.standard.set(data.name, forKey: Const.UserDefaults.Key.userName)
-                    self.makeAlert(title: "회원가입", message: "회원 가입 성공", okAction: { _ in
+                    self.makeAlert(title: "회원가입", message: message, okAction: { _ in
                         self.presentToCheckinViewController()
                     })
                 }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/SignupViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/SignupViewController.swift
@@ -37,14 +37,7 @@ class SignupViewController: UIViewController {
     // MARK: - @IBOutlet Properties
     
     @IBAction func touchSignupButton(_ sender: Any) {
-        let storyboard = UIStoryboard(name: Const.Storyboard.Name.checkin, bundle: nil)
-        guard let checkinVC = storyboard.instantiateViewController(withIdentifier: Const.ViewController.Identifier.checkin) as? CheckinViewController else {
-            return
-        }
-        
-        checkinVC.userName = nameTextField.text
-        checkinVC.modalPresentationStyle = .fullScreen
-        present(checkinVC, animated: true, completion: nil)
+        postSignupWithAPI()
     }
     @IBAction func touchPasswordTextFieldSecure(_ sender: Any) {
         if passwordTextFieldIsSecurity {
@@ -74,6 +67,45 @@ extension SignupViewController {
     private func initTextFieldEmpty() {
         textFieldList.forEach {
             $0.text = ""
+        }
+    }
+    private func presentToCheckinViewController() {
+        let storyboard = UIStoryboard(name: Const.Storyboard.Name.checkin, bundle: nil)
+        guard let checkinVC = storyboard.instantiateViewController(withIdentifier: Const.ViewController.Identifier.checkin) as? CheckinViewController else {
+            return
+        }
+        
+        checkinVC.userName = nameTextField.text
+        checkinVC.modalPresentationStyle = .fullScreen
+        present(checkinVC, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Network
+
+extension SignupViewController {
+    func postSignupWithAPI() {
+        SignupService.shared.signup(email: contactTextField.text ?? "", name: nameTextField.text ?? "", password: passwordTextField.text ?? "") { response in
+            switch response {
+            case .success(let signupResponse):
+                if let data = signupResponse as? SignupResponseModel {
+                    UserDefaults.standard.set(data.name, forKey: Const.UserDefaults.Key.userName)
+                    self.makeAlert(title: "회원가입", message: "회원 가입 성공", okAction: { _ in
+                        self.presentToCheckinViewController()
+                    })
+                }
+            case .requestErr(let message):
+                if let message = message as? String {
+                    self.makeAlert(title: "회원가입", message: message)
+                }
+            case .pathErr:
+                print("postSignupWithAPI- pathErr")
+            case .serverErr:
+                print("postSignupWithAPI - serverErr")
+            case .networkFail:
+                print("postSignupWithAPI - networkFail")
+            }
+            
         }
     }
 }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/SignupViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/SignupViewController.swift
@@ -74,8 +74,7 @@ extension SignupViewController {
         guard let checkinVC = storyboard.instantiateViewController(withIdentifier: Const.ViewController.Identifier.checkin) as? CheckinViewController else {
             return
         }
-        
-        checkinVC.userName = nameTextField.text
+
         checkinVC.modalPresentationStyle = .fullScreen
         present(checkinVC, animated: true, completion: nil)
     }

--- a/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/TabBar/HomeViewController.swift
+++ b/YoutubeColneCoding/SOPT-29th-iOS-SeminarAssignment/Source/ViewController/TabBar/HomeViewController.swift
@@ -17,6 +17,9 @@ class HomeViewController: UIViewController {
     
     // MARK: - @IBOutlet Properties
     
+    // ✅ CustomNavigationBar 클래스에서 File's Owner 의 Custom Class 설정했을 땣
+//    @IBOutlet weak var customNavigationBar: CustomNavigationBar!
+    
     @IBOutlet weak var customNavigationBar: UIView!
     @IBOutlet weak var channelCollectionView: UICollectionView!
     @IBOutlet weak var categoryCollectionView: UICollectionView!
@@ -38,19 +41,28 @@ class HomeViewController: UIViewController {
 extension HomeViewController {
     private func initNavigationBar() {
         self.navigationController?.navigationBar.isHidden = true
-        // ✅ 커스텀네비게이션바 클래스에서 View 의 Custom Class 를 설정했을 떄 사용하는 코드
+        // ✅ CustomNavigationBar 클래스에서 View 의 Custom Class 를 설정했을 때 사용하는 코드
         guard let loadedNib = Bundle.main.loadNibNamed(String(describing: CustomNavigationBar.self), owner: self, options: nil) else { return }
         guard let navigationBar = loadedNib.first as? CustomNavigationBar else { return }
-        
+
         navigationBar.frame = CGRect(x: 0, y: 0, width: customNavigationBar.frame.width, height: customNavigationBar.frame.height)
         customNavigationBar.addSubview(navigationBar)
+        
+        // ✅ CustomNavigationBar 클래스에서 View 의 Custom Class 를 설정했을 때 이벤트 등록.
+//        navigationBar.profileButton.addTarget(self, action: #selector(touchProfileButton), for: .touchUpInside)
+        navigationBar.presentingViewController = self
+        
+        // ✅ CustomNavigationBar 클래스에서 File's Owner 의 Custom Class 를 설정했을 때 이벤트 등록 코드
+//        customNavigationBar.profileButton.addTarget(self, action: #selector(touchProfileButton), for: .touchUpInside)
     }
     
     private func assignDelegate() {
         channelCollectionView.delegate = self
         channelCollectionView.dataSource = self
+        
         categoryCollectionView.delegate = self
         categoryCollectionView.dataSource = self
+        
         thumbnailTableView.delegate = self
         thumbnailTableView.dataSource = self
     }
@@ -79,10 +91,18 @@ extension HomeViewController {
                                           ThumbnailData(thumbnailImage: "wesoptiOSPart", channelImage: "wesoptProfile", title: "3차 iOS 세미나 : ScrollView, Delegate Pattern, TableView, CollectionView", subtitle: "WE SOPT ・조회수 100만회 ・ 3주 전"),
                                           ThumbnailData(thumbnailImage: "wesoptiOSPart", channelImage: "wesoptProfile", title: "4차 iOS 세미나 : Cocoapods & Networking, REST API", subtitle: "WE SOPT ・조회수 100만회 ・ 3주 전"),
                                           ThumbnailData(thumbnailImage: "wesoptiOSPart", channelImage: "wesoptProfile", title: "7차 iOS 세미나 : Animation과 제스쳐, 데이터 전달 심화 ", subtitle: "WE SOPT ・조회수 100만회 ・ 3주 전")])
-        channelCollectionView.reloadData()
-        categoryCollectionView.reloadData()
-        thumbnailTableView.reloadData()
     }
+    
+    // MARK: - @Objc Methods
+    
+    // ✅ CustomNavigationBar 의 profileButton 이벤트(현재 커스텀뷰로 이동시켜서 공통적으로 작업하도록 함)
+//    @objc
+//    private func touchProfileButton() {
+//        guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginViewController else { return }
+//        loginVC.modalPresentationStyle = .fullScreen
+//        loginVC.modalTransitionStyle = .crossDissolve
+//        present(loginVC, animated: true, completion: nil)
+//    }
 }
 
 // MARK: - UICollectionViewDelegate


### PR DESCRIPTION
## 📌 관련 이슈
close #10
  
## 📌 변경 사항 및 이유
- 로그인, 회원가입 서버통신
- Xib 로 연결한 커스텀뷰의 요소에 액션 등록
- Network 폴더링
```bash
├── Resource
├── Source
│   ├── NetworkModel
│        ├── GenericResponse
│        ├── NetworkResult
│        ├── SignupResponseModel
│        ├── LoginResponseModel
│   ├── NetworkService
│        ├── SignupService
│        ├── LoginService
└── 
```
> GenericResponse: 제네릭을 사용해서 data 부분만 별도로 구현해서 사용할 수 있도록 하는 모델

## 📌 PR Point

- 데이터를 제외한 status, success, message 는 공통적으로 사용하기 때문에 제네릭을 사용해서 옵셔널로 선언한 data 부분만 별도로 구현하였습니다.
- 서버에서 key-value 를 넘겨주지 않더라도 앱이 갑자기 죽지 않도록 처리하였습니다.
- UIAertController 를 쉽게 사용하기 위해서 extension 으로 빼뒀습니다.
- reqeustErr 일 때 서버의 메시지를 Alert 창에서 쓰기 위해서 세미나자료에서 `isValidLoginData()` 메서드 수정했습니다.
- 클라에서 경로 요청 에러시 나오는 404도 대응할 수 있도록 상태코드 범위를 수정했습니다.

## 📌 참고 사항

> `❗️4차` 키워드 검색하면 PRPoint 를 찾을 수 있도록 주석달아뒀습니당.

> [iOS) Xib 로 만든 커스텀뷰에서 액션 연결](https://gyuios.tistory.com/128)

